### PR TITLE
Fix transaction fee calculation

### DIFF
--- a/components/DonationBucket/DonationBucket.tsx
+++ b/components/DonationBucket/DonationBucket.tsx
@@ -24,7 +24,8 @@ export default function DonationBucket() {
 
   let calculateFee = (amount = feeAmount) => {
     if (!amount) return 0
-    let fee = amount * 0.03 + 0.2
+
+    let fee = amount * 0.015 + 0.2
     return fee.toFixed(2)
   }
 


### PR DESCRIPTION
This was previously calculated at 3% but this is incorrect, the correct value is 1.5% + 20p.

3% would be ideal as it covers non-eu cards but this is the minority and we don't want to discourage users from uplifting the donation.

More stripe pricing info can be found here: https://stripe.com/gb/pricing